### PR TITLE
Manage test execution with flag

### DIFF
--- a/PlaygroundTester/Sources/PlaygroundTester/Interface/PlaygroundTesterView.swift
+++ b/PlaygroundTester/Sources/PlaygroundTester/Interface/PlaygroundTesterView.swift
@@ -2,13 +2,24 @@
 
 import SwiftUI
 
-public struct PlaygroundTesterView: View {
+public struct PlaygroundTesterView<Content: View>: View {
+  let content: Content
 
-  public init() {}
+  public init(@ViewBuilder content: () -> Content) {
+    self.content = content()
+  }
 
   public var body: some View {
-    TestingView()
+    if PlaygroundTesterConfigurator.isTesting {
+      TestingView()
+    } else {
+      content
+    }
   }
 }
 
 #endif
+
+public enum PlaygroundTesterConfigurator {
+  public static var isTesting = false
+}

--- a/PlaygroundTesterDemoApp/PlaygroundTesterDemoApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PlaygroundTesterDemoApp/PlaygroundTesterDemoApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,7 +5,7 @@
         "package": "Difference",
         "repositoryURL": "https://github.com/krzysztofzablocki/Difference.git",
         "state": {
-          "branch": null,
+          "branch": "master",
           "revision": "02fe1111edc8318c4f8a0da96336fcbcc201f38b",
           "version": "1.0.1"
         }

--- a/PlaygroundTesterDemoApp/PlaygroundTesterDemoApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PlaygroundTesterDemoApp/PlaygroundTesterDemoApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -7,7 +7,7 @@
         "state": {
           "branch": "master",
           "revision": "02fe1111edc8318c4f8a0da96336fcbcc201f38b",
-          "version": "1.0.1"
+          "version": null
         }
       }
     ]

--- a/PlaygroundTesterDemoApp/PlaygroundTesterDemoApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PlaygroundTesterDemoApp/PlaygroundTesterDemoApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,9 +5,9 @@
         "package": "Difference",
         "repositoryURL": "https://github.com/krzysztofzablocki/Difference.git",
         "state": {
-          "branch": "master",
+          "branch": null,
           "revision": "02fe1111edc8318c4f8a0da96336fcbcc201f38b",
-          "version": null
+          "version": "1.0.1"
         }
       }
     ]

--- a/PlaygroundTesterDemoApp/PlaygroundTesterDemoApp/PlaygroundTesterDemoAppApp.swift
+++ b/PlaygroundTesterDemoApp/PlaygroundTesterDemoApp/PlaygroundTesterDemoAppApp.swift
@@ -10,9 +10,16 @@ import PlaygroundTester
 
 @main
 struct PlaygroundTesterDemoAppApp: App {
+    
+    init() {
+        PlaygroundTester.PlaygroundTesterConfigurator.isTesting = true
+    }
+    
     var body: some Scene {
         WindowGroup {
-          PlaygroundTester.PlaygroundTesterView()
+            PlaygroundTester.PlaygroundTesterView {
+                Text("isTesting is false")
+            }
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -134,15 +134,19 @@ func testSampleExpectation() {
 At this moment unwaited expectations don't trigger an assertion failure.
 
 ### Runing tests
-In order to execute your tests you need to do one final thing : exchange your app view for `PlaygroundTesterView`. 
+In order to execute your tests you need to do one final thing : Set `isTesting` flag to `true` and prepare for `PlaygroundTesterView`.
 In your `App` object just do this : 
 
 ```swift
 struct Myapp: App {
+    init() {
+        PlaygroundTester.PlaygroundTesterConfigurator.isTesting = true
+    }
     var body: some Scene {
         WindowGroup {
-          // YourContentView()
-          PlaygroundTester.PlaygroundTesterView()
+          PlaygroundTester.PlaygroundTesterView {
+            // YourContentView()
+          }
         }
     }
 }


### PR DESCRIPTION
Thank you for a very nice library.
I have a suggestion to make it more user friendly.

In many implementations, such as SDKs for advertising, the tests are managed by flags.
I think this implementation is more Swift-like.

```.swift
@main
struct MyApp: App {
    
    init() {
        PlaygroundTesterConfigurator.isTesting = false
    }
    
    var body: some Scene {
        WindowGroup {
            PlaygroundTesterView {
                // your view
            }
        }
    }
}
```

If you don't mind, please adopt this idea.
Also, it would be helpful if you could revise my comments in the readme to be more appropriate.